### PR TITLE
ci(github-actions): add CI pipeline for tests and build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Base URL for the Daily Gym API
+VITE_API_URL=http://localhost:3000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+          restore-keys: node-modules-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test
+
+      - name: Build
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# Testing
+coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ dist-ssr
 
 # Testing
 coverage/
+.vscode/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+coverage

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,3 +6,90 @@
 - Owner: jorgedjr21
 - Project number: 1
 - Repositório: jorgedjr21/daily_gym_web
+
+## Tech Stack
+
+- **Framework**: Vue 3 with `<script setup>` and Composition API
+- **Language**: TypeScript (strict mode — `any` is an ESLint error)
+- **UI components**: Custom components built on top of Radix Vue primitives
+- **Styling**: Tailwind CSS 3 with CSS custom properties for theming; dark mode via `class` strategy
+- **State management**: Pinia 3
+- **Routing**: Vue Router 4
+- **HTTP client**: Axios
+- **Form handling**: VeeValidate + Zod schema validation
+- **Data fetching**: TanStack Vue Query 5
+- **Icons**: Lucide Vue Next
+- **Utility**: `clsx` + `tailwind-merge` exposed as `cn()` in `src/lib/utils.ts`
+- **Testing**: Vitest 3, Vue Testing Library 8, `@vue/test-utils` 2, jsdom
+- **Build**: Vite 8
+- **Node requirement**: >= 22.0.0
+
+## Project Structure
+
+```
+src/
+  components/
+    ui/             # Primitive UI components (Button, Card, CardHeader, CardContent, Input)
+    ui/__tests__/   # Unit tests co-located with components
+  lib/
+    utils.ts        # cn() helper (clsx + tailwind-merge)
+  test/
+    setup.ts        # Vitest global setup — imports @testing-library/jest-dom
+  App.vue           # Root component
+  main.ts           # App entry point
+  style.css         # Global CSS (Tailwind base + CSS custom properties)
+```
+
+As the project grows, add these directories under `src/`:
+- `pages/` — one component per route
+- `stores/` — Pinia stores
+- `composables/` — reusable `use*` functions
+- `services/` — Axios HTTP layer
+- `types/` — shared TypeScript interfaces
+
+## Dev Workflow (Docker-based via Makefile)
+
+All commands run inside a `node:22-alpine` container. Never run npm directly on the host unless you have Node 22+ installed.
+
+| Task | Command |
+|---|---|
+| Start dev server (port 5173) | `make dev` |
+| Install dependencies | `make install` |
+| Run tests (single pass) | `make test` |
+| Run tests in watch mode | `make test-watch` |
+| Production build | `make build` |
+| Type check | `make type-check` |
+| Lint | `make lint` |
+| Format (Prettier) | `make format` |
+
+`make dev` uses `docker compose up` — the compose file mounts source files and exposes port 5173.
+
+## Component Conventions
+
+- All components use `<script setup lang="ts">` — the ESLint rule `vue/block-lang` enforces this.
+- Props are always typed with a TypeScript `interface` passed to `defineProps<Props>()`.
+- Class merging uses the `cn()` utility from `@/lib/utils`.
+- UI primitives live in `src/components/ui/` and are named in PascalCase (e.g., `Button.vue`, `CardHeader.vue`).
+- When adding a new UI primitive, create its test file at `src/components/ui/__tests__/<ComponentName>.spec.ts`.
+- Variants and sizes are implemented as plain `Record<..., string>` maps resolved at render time (no `class-variance-authority` at runtime — CVA is a dependency but the current components use manual maps).
+
+## Testing Conventions
+
+- Test runner: Vitest with `globals: true` and `environment: jsdom`.
+- Setup file: `src/test/setup.ts` — runs before every test file and imports `@testing-library/jest-dom` matchers.
+- Coverage provider: v8 (`make test` → `npm run test`, `npm run test:coverage` for lcov report).
+- Test files live next to the code they test inside a `__tests__/` directory.
+- Prefer `@vue/test-utils` `mount()` for component unit tests; use `@testing-library/vue` `render()` + `screen` queries for user-facing behaviour tests.
+- Never merge with failing tests (`vitest run` must exit 0).
+
+## Key Config Files
+
+| File | Purpose |
+|---|---|
+| `vite.config.ts` | Vite build config; sets `@` alias to `./src` |
+| `vitest.config.ts` | Vitest config; jsdom env, globals, setup file, v8 coverage |
+| `tailwind.config.ts` | Tailwind theme extending with CSS var-based design tokens; dark mode via `class` |
+| `tsconfig.app.json` | Strict TypeScript config for `src/`; `@/*` path alias |
+| `eslint.config.js` | Flat ESLint config; `no-explicit-any` and `no-unused-vars` are errors |
+| `docker-compose.yml` | Dev container — node:22-alpine, port 5173, named volume for node_modules |
+| `Makefile` | Wraps all npm scripts in Docker `node:22-alpine` one-shot containers |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# Daily Gym WEB
+
+
+## GitHub Project
+
+- Owner: jorgedjr21
+- Project number: 1
+- Repositório: jorgedjr21/daily_gym_web

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+RUN npm install -g npm@latest
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+DOCKER_RUN = docker run --rm -u 1000:1000 -v $(PWD):/app -w /app node:22-alpine
+
+dev:
+	docker compose up
+
+install:
+	$(DOCKER_RUN) npm install
+
+test:
+	$(DOCKER_RUN) npm run test
+
+test-watch:
+	$(DOCKER_RUN) npm run test:watch
+
+build:
+	$(DOCKER_RUN) npm run build
+
+type-check:
+	$(DOCKER_RUN) npm run type-check
+
+lint:
+	$(DOCKER_RUN) npm run lint
+
+format:
+	$(DOCKER_RUN) npm run format
+
+.PHONY: dev install test test-watch build type-check lint format

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Daily Gym Web
+
+Frontend SPA for the Daily Gym workout tracker, built with Vue 3, TypeScript, and Tailwind CSS.
+
+## Stack
+
+- **Vue 3** with `<script setup>` and Composition API
+- **TypeScript** in strict mode
+- **Vite** as build tool
+- **Tailwind CSS** for styling
+- **shadcn-vue** component library (Button, Input, Card)
+- **Pinia** for client state management
+- **TanStack Vue Query** for server state
+- **Vue Router 4** for routing
+- **Vee-Validate + Zod** for form validation
+- **Vitest + @vue/test-utils** for unit/component tests
+
+## Requirements
+
+- Docker and Docker Compose
+
+## Setup
+
+```bash
+cp .env.example .env
+make install
+```
+
+## Scripts
+
+| Command           | Description                              |
+|-------------------|------------------------------------------|
+| `make dev`        | Start dev server at http://localhost:5173 |
+| `make test`       | Run unit tests                           |
+| `make test-watch` | Run tests in watch mode                  |
+| `make build`      | Build for production                     |
+| `make type-check` | Run TypeScript type checking             |
+| `make lint`       | Run ESLint                               |
+| `make format`     | Format code with Prettier                |
+
+## Environment Variables
+
+See `.env.example` for all required variables.
+
+| Variable       | Description              |
+|----------------|--------------------------|
+| `VITE_API_URL` | Base URL of the REST API |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  web:
+    image: node:22-alpine
+    working_dir: /app
+    volumes:
+      - .:/app
+      - web_node_modules:/app/node_modules
+    ports:
+      - "5173:5173"
+    environment:
+      - NODE_ENV=development
+    command: sh -c "npm install && npm run dev -- --host"
+
+volumes:
+  web_node_modules:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,47 @@
+import pluginVue from 'eslint-plugin-vue'
+import tsParser from '@typescript-eslint/parser'
+import tsPlugin from '@typescript-eslint/eslint-plugin'
+import vueParser from 'vue-eslint-parser'
+
+export default [
+  {
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**'],
+  },
+  ...pluginVue.configs['flat/recommended'],
+  {
+    files: ['**/*.vue'],
+    languageOptions: {
+      parser: vueParser,
+      parserOptions: {
+        parser: tsParser,
+        extraFileExtensions: ['.vue'],
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: {
+      'vue/multi-word-component-names': 'off',
+      'vue/block-lang': ['error', { script: { lang: 'ts' } }],
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-unused-vars': 'error',
+    },
+  },
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-unused-vars': 'error',
+    },
+  },
+]

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/components/ui/Button.vue
+++ b/src/components/ui/Button.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { cn } from '@/lib/utils'
+
+interface Props {
+  variant?: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link'
+  size?: 'default' | 'sm' | 'lg' | 'icon'
+  disabled?: boolean
+  type?: 'button' | 'submit' | 'reset'
+  class?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  variant: 'default',
+  size: 'default',
+  disabled: false,
+  type: 'button',
+})
+
+const variantClasses: Record<NonNullable<Props['variant']>, string> = {
+  default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+  destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+  outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+  secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+  ghost: 'hover:bg-accent hover:text-accent-foreground',
+  link: 'text-primary underline-offset-4 hover:underline',
+}
+
+const sizeClasses: Record<NonNullable<Props['size']>, string> = {
+  default: 'h-10 px-4 py-2',
+  sm: 'h-9 rounded-md px-3',
+  lg: 'h-11 rounded-md px-8',
+  icon: 'h-10 w-10',
+}
+
+const classes = computed(() =>
+  cn(
+    'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+    'disabled:pointer-events-none disabled:opacity-50',
+    variantClasses[props.variant],
+    sizeClasses[props.size],
+    props.class,
+  ),
+)
+</script>
+
+<template>
+  <button :class="classes" :disabled="disabled" :type="type">
+    <slot />
+  </button>
+</template>

--- a/src/components/ui/Card.vue
+++ b/src/components/ui/Card.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils'
+
+interface Props {
+  class?: string
+}
+
+const props = defineProps<Props>()
+</script>
+
+<template>
+  <div
+    :class="cn('rounded-lg border bg-card text-card-foreground shadow-sm', props.class)"
+  >
+    <slot />
+  </div>
+</template>

--- a/src/components/ui/CardContent.vue
+++ b/src/components/ui/CardContent.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils'
+
+interface Props {
+  class?: string
+}
+
+const props = defineProps<Props>()
+</script>
+
+<template>
+  <div :class="cn('p-6 pt-0', props.class)">
+    <slot />
+  </div>
+</template>

--- a/src/components/ui/CardHeader.vue
+++ b/src/components/ui/CardHeader.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils'
+
+interface Props {
+  class?: string
+}
+
+const props = defineProps<Props>()
+</script>
+
+<template>
+  <div :class="cn('flex flex-col space-y-1.5 p-6', props.class)">
+    <slot />
+  </div>
+</template>

--- a/src/components/ui/Input.vue
+++ b/src/components/ui/Input.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils'
+
+interface Props {
+  type?: string
+  placeholder?: string
+  disabled?: boolean
+  class?: string
+  modelValue?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  type: 'text',
+  disabled: false,
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+</script>
+
+<template>
+  <input
+    :type="type"
+    :value="modelValue"
+    :placeholder="placeholder"
+    :disabled="disabled"
+    :class="
+      cn(
+        'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background',
+        'file:border-0 file:bg-transparent file:text-sm file:font-medium',
+        'placeholder:text-muted-foreground',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        'disabled:cursor-not-allowed disabled:opacity-50',
+        props.class,
+      )
+    "
+    @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+  />
+</template>

--- a/src/components/ui/__tests__/Button.spec.ts
+++ b/src/components/ui/__tests__/Button.spec.ts
@@ -1,0 +1,28 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import Button from '../Button.vue'
+
+describe('Button', () => {
+  it('renders slot content', () => {
+    const wrapper = mount(Button, { slots: { default: 'Click me' } })
+    expect(wrapper.text()).toBe('Click me')
+  })
+
+  it('renders as a button element', () => {
+    const wrapper = mount(Button, { slots: { default: 'Submit' } })
+    expect(wrapper.element.tagName).toBe('BUTTON')
+  })
+
+  it('is disabled when disabled prop is true', () => {
+    const wrapper = mount(Button, { props: { disabled: true }, slots: { default: 'Disabled' } })
+    expect((wrapper.element as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('applies destructive variant classes', () => {
+    const wrapper = mount(Button, {
+      props: { variant: 'destructive' },
+      slots: { default: 'Delete' },
+    })
+    expect(wrapper.classes()).toContain('bg-destructive')
+  })
+})

--- a/src/components/ui/__tests__/Card.spec.ts
+++ b/src/components/ui/__tests__/Card.spec.ts
@@ -1,0 +1,17 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import Card from '../Card.vue'
+
+describe('Card', () => {
+  it('renders slot content', () => {
+    const wrapper = mount(Card, { slots: { default: 'Card content' } })
+    expect(wrapper.text()).toBe('Card content')
+  })
+
+  it('applies base card styles', () => {
+    const wrapper = mount(Card, { slots: { default: 'Content' } })
+    expect(wrapper.classes()).toContain('rounded-lg')
+    expect(wrapper.classes()).toContain('border')
+    expect(wrapper.classes()).toContain('bg-card')
+  })
+})

--- a/src/components/ui/__tests__/Input.spec.ts
+++ b/src/components/ui/__tests__/Input.spec.ts
@@ -1,0 +1,20 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import Input from '../Input.vue'
+
+describe('Input', () => {
+  it('renders an input element', () => {
+    const wrapper = mount(Input)
+    expect(wrapper.find('input').exists()).toBe(true)
+  })
+
+  it('shows placeholder text', () => {
+    const wrapper = mount(Input, { props: { placeholder: 'Search...' } })
+    expect(wrapper.find('input').attributes('placeholder')).toBe('Search...')
+  })
+
+  it('is disabled when disabled prop is true', () => {
+    const wrapper = mount(Input, { props: { disabled: true } })
+    expect((wrapper.find('input').element as HTMLInputElement).disabled).toBe(true)
+  })
+})

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,76 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 84% 4.9%;
+
+    --radius: 0.5rem;
+  }
+
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,51 @@
+import type { Config } from 'tailwindcss'
+
+export default {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{vue,ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+    },
+  },
+  plugins: [],
+} satisfies Config

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+import { resolve } from 'path'
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      exclude: ['node_modules/', 'src/test/', '**/*.d.ts'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
+})


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` triggered on every push and pull request
- Installs dependencies with `npm ci` and caches `node_modules` keyed on `package-lock.json` hash
- Runs `npm run test` (Vitest) followed by `npm run build` (vue-tsc + Vite) to catch both test failures and TypeScript/build errors
- Uses Node 22, matching the version pinned in `Dockerfile` and `package.json` engines

## Test plan

- [x] Open this PR and confirm the `CI` workflow is triggered automatically
- [x] Verify the `test-and-build` job passes (green check)
- [x] Introduce a deliberate test failure in a branch to confirm the pipeline catches it
- [x] Confirm cache hit on a second run (no install from scratch)