### PR TITLE
feat(api): configure API client with JWT token injection and 401 handling

### DIFF
--- a/src/lib/__tests__/api.spec.ts
+++ b/src/lib/__tests__/api.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import axios from 'axios'
+
+vi.mock('axios', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('axios')>()
+  const instance = {
+    defaults: { baseURL: '' },
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  }
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      create: vi.fn(() => instance),
+    },
+  }
+})
+
+describe('api client', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('creates an axios instance with the VITE_API_URL base URL', async () => {
+    await import('../api')
+    expect(axios.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: expect.any(String),
+      }),
+    )
+  })
+
+  describe('request interceptor', () => {
+    it('registers a request interceptor on the instance', async () => {
+      const { api } = await import('../api')
+      expect(api.interceptors.request.use).toHaveBeenCalledTimes(1)
+    })
+
+    it('injects Authorization header when token is present', async () => {
+      localStorage.setItem('auth_token', 'test-jwt-token')
+
+      const { requestInterceptor } = await import('../api')
+      const config = { headers: {} as Record<string, string> }
+      const result = requestInterceptor(config as Parameters<typeof requestInterceptor>[0])
+
+      expect((result.headers as Record<string, string>)['Authorization']).toBe('test-jwt-token')
+    })
+
+    it('does not inject Authorization header when token is absent', async () => {
+      const { requestInterceptor } = await import('../api')
+      const config = { headers: {} as Record<string, string> }
+      const result = requestInterceptor(config as Parameters<typeof requestInterceptor>[0])
+
+      expect((result.headers as Record<string, string>)['Authorization']).toBeUndefined()
+    })
+  })
+
+  describe('response interceptor', () => {
+    it('registers a response interceptor on the instance', async () => {
+      const { api } = await import('../api')
+      expect(api.interceptors.response.use).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls authStore.logout and redirects to /login on 401', async () => {
+      const { useAuthStore } = await import('@/stores/auth')
+      const store = useAuthStore()
+      const logoutSpy = vi.spyOn(store, 'logout')
+
+      const mockRouterPush = vi.fn()
+      vi.doMock('@/router', () => ({ default: { push: mockRouterPush } }))
+
+      const { responseErrorInterceptor } = await import('../api')
+      const error = {
+        response: { status: 401 },
+        config: {},
+        message: 'Unauthorized',
+        isAxiosError: true,
+      }
+
+      await expect(responseErrorInterceptor(error)).rejects.toEqual(error)
+      expect(logoutSpy).toHaveBeenCalled()
+    })
+
+    it('passes through non-401 errors without triggering logout', async () => {
+      const { useAuthStore } = await import('@/stores/auth')
+      const store = useAuthStore()
+      const logoutSpy = vi.spyOn(store, 'logout')
+
+      const { responseErrorInterceptor } = await import('../api')
+      const error = {
+        response: { status: 500 },
+        config: {},
+        message: 'Internal Server Error',
+        isAxiosError: true,
+      }
+
+      await expect(responseErrorInterceptor(error)).rejects.toEqual(error)
+      expect(logoutSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,35 @@
+import axios from 'axios'
+import type { InternalAxiosRequestConfig, AxiosResponse, AxiosError } from 'axios'
+import { useAuthStore } from '@/stores/auth'
+import router from '@/router'
+
+export const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL ?? '',
+})
+
+export function requestInterceptor(
+  config: InternalAxiosRequestConfig,
+): InternalAxiosRequestConfig {
+  const token = localStorage.getItem('auth_token')
+  if (token) {
+    config.headers = config.headers ?? {}
+    ;(config.headers as Record<string, string>)['Authorization'] = token
+  }
+  return config
+}
+
+export function responseErrorInterceptor(error: unknown): Promise<never> {
+  const axiosError = error as AxiosError
+  if (axiosError.response?.status === 401) {
+    const authStore = useAuthStore()
+    authStore.logout()
+    router.push({ name: 'login' })
+  }
+  return Promise.reject(error)
+}
+
+api.interceptors.request.use(requestInterceptor)
+api.interceptors.response.use(
+  (response: AxiosResponse) => response,
+  responseErrorInterceptor,
+)

--- a/src/services/health.service.ts
+++ b/src/services/health.service.ts
@@ -1,14 +1,9 @@
-import axios from 'axios'
+import { api } from '@/lib/api'
 
 interface HealthCheckResponse {
   status: string
 }
 
 export const healthService = {
-  check: () =>
-    axios
-      .get<HealthCheckResponse>(
-        `${import.meta.env.VITE_API_URL ?? ''}/health`,
-      )
-      .then((r) => r.data),
+  check: () => api.get<HealthCheckResponse>('/health').then((r) => r.data),
 }


### PR DESCRIPTION
## Summary

- Adds `src/lib/api.ts` — an axios instance pre-configured with `VITE_API_URL` as base URL
- Request interceptor reads the token from `localStorage` and injects it as the `Authorization` header (no `Bearer` prefix, matching `devise-jwt` expectations)
- Response interceptor catches 401 responses, calls `authStore.logout()` to clear memory and `localStorage`, then redirects the user to `/login`
- Exported `requestInterceptor` and `responseErrorInterceptor` functions allow unit-testing interceptor logic in isolation without mocking the full axios lifecycle
- Updates `health.service.ts` to use the centralized client instead of raw axios

## Test plan

- [x] `npx vitest run` — 43 tests pass (7 new for the api client)
- [x] `npx vue-tsc --noEmit` — zero type errors
- [x] Request interceptor: injects header when token present, skips when absent
- [x] Response interceptor: triggers logout on 401, passes through all other error codes

Closes #6