### PR TITLE
feat(auth): implement login page with email/password form

### DIFF
--- a/src/pages/LoginPage.vue
+++ b/src/pages/LoginPage.vue
@@ -1,6 +1,107 @@
 <script setup lang="ts">
+import { ref } from 'vue'
+import { useForm } from 'vee-validate'
+import { toTypedSchema } from '@vee-validate/zod'
+import { z } from 'zod'
+import { useMutation } from '@tanstack/vue-query'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+import { authService } from '@/services/auth.service'
+import Card from '@/components/ui/Card.vue'
+import CardHeader from '@/components/ui/CardHeader.vue'
+import CardContent from '@/components/ui/CardContent.vue'
+import Input from '@/components/ui/Input.vue'
+import Button from '@/components/ui/Button.vue'
+
+const router = useRouter()
+const authStore = useAuthStore()
+
+const loginSchema = toTypedSchema(
+  z.object({
+    email: z
+      .string({ required_error: 'Email is required' })
+      .min(1, 'Email is required')
+      .email('Invalid email address'),
+    password: z
+      .string({ required_error: 'Password is required' })
+      .min(1, 'Password is required')
+      .min(8, 'Password must have at least 8 characters'),
+  }),
+)
+
+const { handleSubmit, defineField, errors } = useForm({ validationSchema: loginSchema })
+
+const [email, emailAttrs] = defineField('email')
+const [password, passwordAttrs] = defineField('password')
+
+const serverError = ref<string | null>(null)
+
+const { mutate, isPending } = useMutation({
+  mutationFn: (payload: Parameters<typeof authService.login>[0]) => authService.login(payload),
+  onSuccess(data) {
+    authStore.login(data.token, data.user)
+    router.push({ name: 'dashboard' })
+  },
+  onError() {
+    serverError.value = 'Invalid email or password.'
+  },
+})
+
+const onSubmit = handleSubmit((values) => {
+  serverError.value = null
+  mutate(values)
+})
 </script>
 
 <template>
-  <div>Login</div>
+  <div class="flex min-h-screen items-center justify-center bg-background p-4">
+    <Card class="w-full max-w-sm">
+      <CardHeader>
+        <h1 class="text-2xl font-bold">Sign in</h1>
+        <p class="text-sm text-muted-foreground">Enter your credentials to continue</p>
+      </CardHeader>
+      <CardContent>
+        <form class="space-y-4" @submit.prevent="onSubmit">
+          <div class="space-y-1">
+            <label class="text-sm font-medium" for="email">Email</label>
+            <Input
+              id="email"
+              v-model="email"
+              v-bind="emailAttrs"
+              type="email"
+              placeholder="you@example.com"
+              :disabled="isPending"
+            />
+            <p v-if="errors.email" class="text-sm text-destructive">{{ errors.email }}</p>
+          </div>
+
+          <div class="space-y-1">
+            <label class="text-sm font-medium" for="password">Password</label>
+            <Input
+              id="password"
+              v-model="password"
+              v-bind="passwordAttrs"
+              type="password"
+              placeholder="••••••••"
+              :disabled="isPending"
+            />
+            <p v-if="errors.password" class="text-sm text-destructive">{{ errors.password }}</p>
+          </div>
+
+          <p v-if="serverError" class="text-sm text-destructive">{{ serverError }}</p>
+
+          <Button type="submit" class="w-full" :disabled="isPending">
+            {{ isPending ? 'Signing in…' : 'Sign in' }}
+          </Button>
+        </form>
+
+        <p class="mt-4 text-center text-sm text-muted-foreground">
+          Don't have an account?
+          <RouterLink :to="{ name: 'register' }" class="font-medium text-primary hover:underline">
+            Sign up
+          </RouterLink>
+        </p>
+      </CardContent>
+    </Card>
+  </div>
 </template>

--- a/src/pages/__tests__/LoginPage.spec.ts
+++ b/src/pages/__tests__/LoginPage.spec.ts
@@ -44,7 +44,7 @@ function buildGlobalConfig() {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
   return {
-    plugins: [pinia, router, [VueQueryPlugin, { queryClient }]],
+    plugins: [pinia, router, [VueQueryPlugin, { queryClient }] as [typeof VueQueryPlugin, { queryClient: QueryClient }]],
   }
 }
 

--- a/src/pages/__tests__/LoginPage.spec.ts
+++ b/src/pages/__tests__/LoginPage.spec.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { nextTick } from 'vue'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import { VueQueryPlugin, QueryClient } from '@tanstack/vue-query'
+import LoginPage from '../LoginPage.vue'
+
+const mockLogin = vi.fn()
+const mockRouterPush = vi.fn()
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    login: mockLogin,
+    isAuthenticated: false,
+  }),
+}))
+
+vi.mock('@/services/auth.service', () => ({
+  authService: {
+    login: vi.fn(),
+  },
+}))
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  return {
+    ...actual,
+    useRouter: () => ({ push: mockRouterPush }),
+  }
+})
+
+function buildGlobalConfig() {
+  const pinia = createPinia()
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: { template: '<div />' } },
+      { path: '/login', name: 'login', component: LoginPage },
+      { path: '/dashboard', name: 'dashboard', component: { template: '<div />' } },
+      { path: '/register', name: 'register', component: { template: '<div />' } },
+    ],
+  })
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+  return {
+    plugins: [pinia, router, [VueQueryPlugin, { queryClient }]],
+  }
+}
+
+function mountLoginPage() {
+  return mount(LoginPage, { global: buildGlobalConfig(), attachTo: document.body })
+}
+
+type LoginWrapper = ReturnType<typeof mountLoginPage>
+
+async function submitForm(wrapper: LoginWrapper) {
+  await (wrapper.vm as unknown as { onSubmit: (e: Event) => void }).onSubmit(
+    new Event('submit'),
+  )
+  await flushPromises()
+  await nextTick()
+  await flushPromises()
+}
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('renders email and password fields', () => {
+    const wrapper = mountLoginPage()
+    expect(wrapper.find('input#email').exists()).toBe(true)
+    expect(wrapper.find('input#password').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('renders a submit button', () => {
+    const wrapper = mountLoginPage()
+    expect(wrapper.find('button[type="submit"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('renders a link to the register page', () => {
+    const wrapper = mountLoginPage()
+    const link = wrapper.find('a[href="/register"]')
+    expect(link.exists()).toBe(true)
+    expect(link.text()).toMatch(/sign up/i)
+    wrapper.unmount()
+  })
+
+  it('shows validation error when email is empty on submit', async () => {
+    const wrapper = mountLoginPage()
+    await submitForm(wrapper)
+    expect(wrapper.text()).toMatch(/email is required/i)
+    wrapper.unmount()
+  })
+
+  it('shows validation error when email format is invalid', async () => {
+    const wrapper = mountLoginPage()
+    await wrapper.find('input#email').setValue('not-an-email')
+    await submitForm(wrapper)
+    expect(wrapper.text()).toMatch(/invalid email/i)
+    wrapper.unmount()
+  })
+
+  it('shows validation error when password is empty on submit', async () => {
+    const wrapper = mountLoginPage()
+    await wrapper.find('input#email').setValue('user@example.com')
+    await submitForm(wrapper)
+    expect(wrapper.text()).toMatch(/password is required/i)
+    wrapper.unmount()
+  })
+
+  it('shows validation error when password is too short', async () => {
+    const wrapper = mountLoginPage()
+    await wrapper.find('input#email').setValue('user@example.com')
+    await wrapper.find('input#password').setValue('short')
+    await submitForm(wrapper)
+    expect(wrapper.text()).toMatch(/at least 8 characters/i)
+    wrapper.unmount()
+  })
+
+  it('calls authService.login and redirects to dashboard on success', async () => {
+    const { authService } = await import('@/services/auth.service')
+    vi.mocked(authService.login).mockResolvedValueOnce({
+      token: 'jwt-token',
+      user: {
+        id: 1,
+        email: 'user@example.com',
+        name: 'Test User',
+        role: 'user',
+        created_at: '2024-01-01T00:00:00Z',
+      },
+    })
+
+    const wrapper = mountLoginPage()
+    await wrapper.find('input#email').setValue('user@example.com')
+    await wrapper.find('input#password').setValue('password123')
+    await submitForm(wrapper)
+
+    expect(authService.login).toHaveBeenCalledWith({
+      email: 'user@example.com',
+      password: 'password123',
+    })
+    expect(mockLogin).toHaveBeenCalledWith(
+      'jwt-token',
+      expect.objectContaining({ email: 'user@example.com' }),
+    )
+    expect(mockRouterPush).toHaveBeenCalledWith({ name: 'dashboard' })
+    wrapper.unmount()
+  })
+
+  it('disables the submit button while loading', async () => {
+    const { authService } = await import('@/services/auth.service')
+    vi.mocked(authService.login).mockImplementation(() => new Promise(() => {}))
+
+    const wrapper = mountLoginPage()
+    await wrapper.find('input#email').setValue('user@example.com')
+    await wrapper.find('input#password').setValue('password123')
+
+    await submitForm(wrapper)
+
+    expect(wrapper.text()).toMatch(/signing in/i)
+    wrapper.unmount()
+  })
+
+  it('shows an error message on login failure', async () => {
+    const { authService } = await import('@/services/auth.service')
+    const error = { response: { status: 401, data: { error: 'Invalid credentials' } } }
+    vi.mocked(authService.login).mockRejectedValueOnce(error)
+
+    const wrapper = mountLoginPage()
+    await wrapper.find('input#email').setValue('user@example.com')
+    await wrapper.find('input#password').setValue('wrongpassword')
+    await submitForm(wrapper)
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.text()).toMatch(/invalid email or password/i)
+    wrapper.unmount()
+  })
+})

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,0 +1,15 @@
+import { api } from '@/lib/api'
+import type { User, LoginPayload } from '@/types/auth'
+
+interface LoginResponse {
+  token: string
+  user: User
+}
+
+export const authService = {
+  login: (payload: LoginPayload) =>
+    api.post<LoginResponse>('/users/sign_in', { user: payload }).then((r) => ({
+      token: r.headers['authorization'] as string,
+      user: r.data.user,
+    })),
+}


### PR DESCRIPTION
## Summary

- Implements `LoginPage` with email/password form validated by Vee-Validate + Zod
- Adds `authService.login` that posts to `POST /users/sign_in` and extracts the JWT from the `Authorization` response header
- On success: stores token via `authStore.login()` and redirects to `/dashboard`
- On failure: shows inline "Invalid email or password." message
- Loading state disables inputs and changes button label to "Signing in…"
- Link to `/register` for new users

Closes #8

## Test plan

- [x] All 53 tests pass (`npx vitest run`)
- [x] `npx vue-tsc --noEmit` clean
- [x] Renders email and password fields
- [x] Validates empty email (required), invalid format, empty password (required), password too short
- [x] Calls `authService.login` with correct payload and redirects on success
- [x] Disables button (shows "Signing in…") while mutation is pending
- [x] Shows error message on login failure