### PR TITLE
chore(dx): add husky pre-commit hook for TypeScript type checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,8 @@ jobs:
       - name: Run tests
         run: npm run test
 
+      - name: Type check
+        run: npm run typecheck
+
       - name: Build
         run: npm run build

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm run typecheck

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "autoprefixer": "^10.4.21",
         "eslint": "^9.27.0",
         "eslint-plugin-vue": "^9.33.0",
+        "husky": "^9.1.7",
         "jsdom": "^26.1.0",
         "postcss": "^8.5.3",
         "prettier": "^3.5.3",
@@ -4793,6 +4794,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "typecheck": "vue-tsc -b --noEmit",
     "type-check": "vue-tsc --noEmit",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
-    "format": "prettier --write src"
+    "format": "prettier --write src",
+    "prepare": "husky"
   },
   "dependencies": {
     "@tanstack/vue-query": "^5.75.0",
@@ -48,6 +50,7 @@
     "autoprefixer": "^10.4.21",
     "eslint": "^9.27.0",
     "eslint-plugin-vue": "^9.33.0",
+    "husky": "^9.1.7",
     "jsdom": "^26.1.0",
     "postcss": "^8.5.3",
     "prettier": "^3.5.3",


### PR DESCRIPTION
## Summary

- Install husky and configure a pre-commit hook that runs `vue-tsc -b --noEmit` before every commit, blocking it when TypeScript errors are present
- Add a `typecheck` script to `package.json` (used by both the hook and the CI step)
- Add an explicit **Type check** step in the CI workflow that runs before **Build**, so TypeScript errors surface with a clear failure label instead of being buried in build output

## Test plan

- [ ] Introduce a deliberate TypeScript error in a `.vue` or `.ts` file and verify `git commit` is blocked with a type error message
- [ ] Fix the error and verify the commit goes through
- [ ] Verify `npm run typecheck` exits 0 on a clean codebase
- [ ] Verify the CI pipeline shows a distinct "Type check" step that fails before reaching "Build"