### PR TITLE
feat(auth): implement registration page

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   web:
     image: node:22-alpine
     working_dir: /app
+    env_file: .env
     volumes:
       - .:/app
       - web_node_modules:/app/node_modules

--- a/src/pages/RegisterPage.vue
+++ b/src/pages/RegisterPage.vue
@@ -1,6 +1,232 @@
 <script setup lang="ts">
+import { ref } from 'vue'
+import { useForm } from 'vee-validate'
+import { toTypedSchema } from '@vee-validate/zod'
+import { z } from 'zod'
+import { useMutation } from '@tanstack/vue-query'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+import { authService } from '@/services/auth.service'
+import Card from '@/components/ui/Card.vue'
+import CardHeader from '@/components/ui/CardHeader.vue'
+import CardContent from '@/components/ui/CardContent.vue'
+import Input from '@/components/ui/Input.vue'
+import Button from '@/components/ui/Button.vue'
+
+const router = useRouter()
+const authStore = useAuthStore()
+
+const registerSchema = toTypedSchema(
+  z
+    .object({
+      name: z.string({ required_error: 'Name is required' }).min(1, 'Name is required'),
+      email: z
+        .string({ required_error: 'Email is required' })
+        .min(1, 'Email is required')
+        .email('Invalid email address'),
+      password: z
+        .string({ required_error: 'Password is required' })
+        .min(1, 'Password is required')
+        .min(8, 'Password must have at least 8 characters'),
+      password_confirmation: z
+        .string({ required_error: 'Password confirmation is required' })
+        .min(1, 'Password confirmation is required'),
+    })
+    .refine((data) => data.password === data.password_confirmation, {
+      message: 'Passwords do not match',
+      path: ['password_confirmation'],
+    }),
+)
+
+const { handleSubmit, defineField, errors, setFieldError } = useForm({
+  validationSchema: registerSchema,
+})
+
+const [name, nameAttrs] = defineField('name')
+const [email, emailAttrs] = defineField('email')
+const [password, passwordAttrs] = defineField('password')
+const [passwordConfirmation, passwordConfirmationAttrs] = defineField('password_confirmation')
+
+const serverError = ref<string | null>(null)
+
+interface ServerErrors {
+  email?: string[]
+  name?: string[]
+  password?: string[]
+  password_confirmation?: string[]
+}
+
+interface ApiError {
+  response?: {
+    status: number
+    data?: { errors?: ServerErrors }
+  }
+}
+
+const { mutate, isPending } = useMutation({
+  mutationFn: (payload: Parameters<typeof authService.register>[0]) =>
+    authService.register(payload),
+  onSuccess(data) {
+    authStore.login(data.token, data.user)
+    router.push({ name: 'dashboard' })
+  },
+  onError(error: unknown) {
+    const apiError = error as ApiError
+    const fieldErrors = apiError.response?.data?.errors
+
+    if (fieldErrors && Object.keys(fieldErrors).length > 0) {
+      const fields: (keyof ServerErrors)[] = ['name', 'email', 'password', 'password_confirmation']
+
+      let mapped = false
+      for (const field of fields) {
+        const messages = fieldErrors[field]
+        if (messages && messages.length > 0) {
+          setFieldError(field, messages[0])
+          mapped = true
+        }
+      }
+
+      if (!mapped) {
+        serverError.value = 'Registration failed. Please try again.'
+      }
+    } else {
+      serverError.value = 'Registration failed. Please try again.'
+    }
+  },
+})
+
+const onSubmit = handleSubmit((values) => {
+  serverError.value = null
+  mutate(values)
+})
 </script>
 
 <template>
-  <div>Register</div>
+  <div class="flex min-h-screen items-center justify-center bg-background p-4">
+    <Card class="w-full max-w-sm">
+      <CardHeader>
+        <h1 class="text-2xl font-bold">
+          Create account
+        </h1>
+        <p class="text-sm text-muted-foreground">
+          Fill in your details to get started
+        </p>
+      </CardHeader>
+      <CardContent>
+        <form
+          class="space-y-4"
+          @submit.prevent="onSubmit"
+        >
+          <div class="space-y-1">
+            <label
+              class="text-sm font-medium"
+              for="name"
+            >Name</label>
+            <Input
+              id="name"
+              v-model="name"
+              v-bind="nameAttrs"
+              type="text"
+              placeholder="John Doe"
+              :disabled="isPending"
+            />
+            <p
+              v-if="errors.name"
+              class="text-sm text-destructive"
+            >
+              {{ errors.name }}
+            </p>
+          </div>
+
+          <div class="space-y-1">
+            <label
+              class="text-sm font-medium"
+              for="email"
+            >Email</label>
+            <Input
+              id="email"
+              v-model="email"
+              v-bind="emailAttrs"
+              type="email"
+              placeholder="you@example.com"
+              :disabled="isPending"
+            />
+            <p
+              v-if="errors.email"
+              class="text-sm text-destructive"
+            >
+              {{ errors.email }}
+            </p>
+          </div>
+
+          <div class="space-y-1">
+            <label
+              class="text-sm font-medium"
+              for="password"
+            >Password</label>
+            <Input
+              id="password"
+              v-model="password"
+              v-bind="passwordAttrs"
+              type="password"
+              placeholder="••••••••"
+              :disabled="isPending"
+            />
+            <p
+              v-if="errors.password"
+              class="text-sm text-destructive"
+            >
+              {{ errors.password }}
+            </p>
+          </div>
+
+          <div class="space-y-1">
+            <label
+              class="text-sm font-medium"
+              for="password_confirmation"
+            >Confirm password</label>
+            <Input
+              id="password_confirmation"
+              v-model="passwordConfirmation"
+              v-bind="passwordConfirmationAttrs"
+              type="password"
+              placeholder="••••••••"
+              :disabled="isPending"
+            />
+            <p
+              v-if="errors.password_confirmation"
+              class="text-sm text-destructive"
+            >
+              {{ errors.password_confirmation }}
+            </p>
+          </div>
+
+          <p
+            v-if="serverError"
+            class="text-sm text-destructive"
+          >
+            {{ serverError }}
+          </p>
+
+          <Button
+            type="submit"
+            class="w-full"
+            :disabled="isPending"
+          >
+            {{ isPending ? 'Creating account…' : 'Create account' }}
+          </Button>
+        </form>
+
+        <p class="mt-4 text-center text-sm text-muted-foreground">
+          Already have an account?
+          <RouterLink
+            :to="{ name: 'login' }"
+            class="font-medium text-primary hover:underline"
+          >
+            Sign in
+          </RouterLink>
+        </p>
+      </CardContent>
+    </Card>
+  </div>
 </template>

--- a/src/pages/__tests__/RegisterPage.spec.ts
+++ b/src/pages/__tests__/RegisterPage.spec.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { nextTick } from 'vue'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import { VueQueryPlugin, QueryClient } from '@tanstack/vue-query'
+import RegisterPage from '../RegisterPage.vue'
+
+const mockLogin = vi.fn()
+const mockRouterPush = vi.fn()
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    login: mockLogin,
+    isAuthenticated: false,
+  }),
+}))
+
+vi.mock('@/services/auth.service', () => ({
+  authService: {
+    register: vi.fn(),
+  },
+}))
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  return {
+    ...actual,
+    useRouter: () => ({ push: mockRouterPush }),
+  }
+})
+
+function buildGlobalConfig() {
+  const pinia = createPinia()
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: { template: '<div />' } },
+      { path: '/login', name: 'login', component: { template: '<div />' } },
+      { path: '/register', name: 'register', component: RegisterPage },
+      { path: '/dashboard', name: 'dashboard', component: { template: '<div />' } },
+    ],
+  })
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+  return {
+    plugins: [
+      pinia,
+      router,
+      [VueQueryPlugin, { queryClient }] as [typeof VueQueryPlugin, { queryClient: QueryClient }],
+    ],
+  }
+}
+
+function mountRegisterPage() {
+  return mount(RegisterPage, { global: buildGlobalConfig(), attachTo: document.body })
+}
+
+type RegisterWrapper = ReturnType<typeof mountRegisterPage>
+
+async function submitForm(wrapper: RegisterWrapper) {
+  await (wrapper.vm as unknown as { onSubmit: (e: Event) => void }).onSubmit(new Event('submit'))
+  await flushPromises()
+  await nextTick()
+  await flushPromises()
+}
+
+describe('RegisterPage', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('renders name, email, password and password_confirmation fields', () => {
+    const wrapper = mountRegisterPage()
+    expect(wrapper.find('input#name').exists()).toBe(true)
+    expect(wrapper.find('input#email').exists()).toBe(true)
+    expect(wrapper.find('input#password').exists()).toBe(true)
+    expect(wrapper.find('input#password_confirmation').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('renders a submit button', () => {
+    const wrapper = mountRegisterPage()
+    expect(wrapper.find('button[type="submit"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('renders a link to the login page', () => {
+    const wrapper = mountRegisterPage()
+    const link = wrapper.find('a[href="/login"]')
+    expect(link.exists()).toBe(true)
+    expect(link.text()).toMatch(/sign in/i)
+    wrapper.unmount()
+  })
+
+  it('shows validation error when name is empty on submit', async () => {
+    const wrapper = mountRegisterPage()
+    await submitForm(wrapper)
+    expect(wrapper.text()).toMatch(/name is required/i)
+    wrapper.unmount()
+  })
+
+  it('shows validation error when email is empty on submit', async () => {
+    const wrapper = mountRegisterPage()
+    await wrapper.find('input#name').setValue('John Doe')
+    await submitForm(wrapper)
+    expect(wrapper.text()).toMatch(/email is required/i)
+    wrapper.unmount()
+  })
+
+  it('shows validation error when email format is invalid', async () => {
+    const wrapper = mountRegisterPage()
+    await wrapper.find('input#name').setValue('John Doe')
+    await wrapper.find('input#email').setValue('not-an-email')
+    await submitForm(wrapper)
+    expect(wrapper.text()).toMatch(/invalid email/i)
+    wrapper.unmount()
+  })
+
+  it('shows validation error when password is too short', async () => {
+    const wrapper = mountRegisterPage()
+    await wrapper.find('input#name').setValue('John Doe')
+    await wrapper.find('input#email').setValue('john@example.com')
+    await wrapper.find('input#password').setValue('short')
+    await submitForm(wrapper)
+    expect(wrapper.text()).toMatch(/at least 8 characters/i)
+    wrapper.unmount()
+  })
+
+  it('shows validation error when passwords do not match', async () => {
+    const wrapper = mountRegisterPage()
+    await wrapper.find('input#name').setValue('John Doe')
+    await wrapper.find('input#email').setValue('john@example.com')
+    await wrapper.find('input#password').setValue('password123')
+    await wrapper.find('input#password_confirmation').setValue('different123')
+    await submitForm(wrapper)
+    expect(wrapper.text()).toMatch(/passwords do not match/i)
+    wrapper.unmount()
+  })
+
+  it('calls authService.register and redirects to dashboard on success', async () => {
+    const { authService } = await import('@/services/auth.service')
+    vi.mocked(authService.register).mockResolvedValueOnce({
+      token: 'jwt-token',
+      user: {
+        id: 1,
+        email: 'john@example.com',
+        name: 'John Doe',
+        role: 'user',
+        created_at: '2024-01-01T00:00:00Z',
+      },
+    })
+
+    const wrapper = mountRegisterPage()
+    await wrapper.find('input#name').setValue('John Doe')
+    await wrapper.find('input#email').setValue('john@example.com')
+    await wrapper.find('input#password').setValue('password123')
+    await wrapper.find('input#password_confirmation').setValue('password123')
+    await submitForm(wrapper)
+
+    expect(authService.register).toHaveBeenCalledWith({
+      name: 'John Doe',
+      email: 'john@example.com',
+      password: 'password123',
+      password_confirmation: 'password123',
+    })
+    expect(mockLogin).toHaveBeenCalledWith(
+      'jwt-token',
+      expect.objectContaining({ email: 'john@example.com' }),
+    )
+    expect(mockRouterPush).toHaveBeenCalledWith({ name: 'dashboard' })
+    wrapper.unmount()
+  })
+
+  it('disables the submit button while loading', async () => {
+    const { authService } = await import('@/services/auth.service')
+    vi.mocked(authService.register).mockImplementation(() => new Promise(() => {}))
+
+    const wrapper = mountRegisterPage()
+    await wrapper.find('input#name').setValue('John Doe')
+    await wrapper.find('input#email').setValue('john@example.com')
+    await wrapper.find('input#password').setValue('password123')
+    await wrapper.find('input#password_confirmation').setValue('password123')
+
+    await submitForm(wrapper)
+
+    expect(wrapper.text()).toMatch(/creating account/i)
+    wrapper.unmount()
+  })
+
+  it('shows server error when registration fails with generic error', async () => {
+    const { authService } = await import('@/services/auth.service')
+    vi.mocked(authService.register).mockRejectedValueOnce({
+      response: { status: 422, data: { errors: {} } },
+    })
+
+    const wrapper = mountRegisterPage()
+    await wrapper.find('input#name').setValue('John Doe')
+    await wrapper.find('input#email').setValue('john@example.com')
+    await wrapper.find('input#password').setValue('password123')
+    await wrapper.find('input#password_confirmation').setValue('password123')
+    await submitForm(wrapper)
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.text()).toMatch(/registration failed/i)
+    wrapper.unmount()
+  })
+
+  it('maps server email error to email field', async () => {
+    const { authService } = await import('@/services/auth.service')
+    vi.mocked(authService.register).mockRejectedValueOnce({
+      response: {
+        status: 422,
+        data: { errors: { email: ['has already been taken'] } },
+      },
+    })
+
+    const wrapper = mountRegisterPage()
+    await wrapper.find('input#name').setValue('John Doe')
+    await wrapper.find('input#email').setValue('john@example.com')
+    await wrapper.find('input#password').setValue('password123')
+    await wrapper.find('input#password_confirmation').setValue('password123')
+    await submitForm(wrapper)
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.text()).toMatch(/has already been taken/i)
+    wrapper.unmount()
+  })
+})

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,14 +1,20 @@
 import { api } from '@/lib/api'
-import type { User, LoginPayload } from '@/types/auth'
+import type { User, LoginPayload, RegisterPayload } from '@/types/auth'
 
-interface LoginResponse {
+interface AuthResponse {
   token: string
   user: User
 }
 
 export const authService = {
   login: (payload: LoginPayload) =>
-    api.post<LoginResponse>('/users/sign_in', { user: payload }).then((r) => ({
+    api.post<AuthResponse>('/users/sign_in', { user: payload }).then((r) => ({
+      token: r.headers['authorization'] as string,
+      user: r.data.user,
+    })),
+
+  register: (payload: RegisterPayload) =>
+    api.post<AuthResponse>('/users', { user: payload }).then((r) => ({
       token: r.headers['authorization'] as string,
       user: r.data.user,
     })),


### PR DESCRIPTION
## Summary
- Adds `authService.register`, posting to `POST /users` and extracting the JWT the same way `login` does.
- Implements `RegisterPage` with VeeValidate + Zod validation (email format, password >= 8 chars, password confirmation match), success flow (persist token, redirect to `/dashboard`), and server-side validation error mapping per field.
- Loads `.env` into the web dev container so `VITE_API_URL` is available.

Closes #9

## Test plan
- [x] `make test` — 65/65 passing (12 new for RegisterPage)
- [x] `make type-check` / `npm run typecheck` (husky pre-commit gate) — clean
- [x] `make lint` — 0 errors on touched files
- [x] Manual: registered a user via `/register` in the browser against the local API, redirected to `/dashboard` with token persisted

## Note
Newly registered users get `role: "member"` once `jorgedjr21/daily_gym_api#85` is merged (currently open) — until then the API returns `role: null`, unrelated to this PR.